### PR TITLE
Correct spelling of pyobjc

### DIFF
--- a/requirements-darwin.txt
+++ b/requirements-darwin.txt
@@ -1,3 +1,3 @@
 pyobjc
-pybojc-framework-Cocoa
+pyobjc-framework-Cocoa
 pyobjc-framework-Quartz


### PR DESCRIPTION
Correcting the spelling for the requirements install